### PR TITLE
New: endpoint to transfer content ownership between users (fixes #49)

### DIFF
--- a/errors/errors.json
+++ b/errors/errors.json
@@ -12,5 +12,12 @@
     },
     "description": "You cannot delete your own user account",
     "statusCode": 400
+  },
+  "INVALID_TRANSFER_TARGET": {
+    "data": {
+      "_toUser": "_id of the intended new owner"
+    },
+    "description": "A valid _toUser (an existing user, different from the current owner) must be supplied to transfer content",
+    "statusCode": 400
   }
 }

--- a/lib/UsersModule.js
+++ b/lib/UsersModule.js
@@ -138,6 +138,22 @@ class UsersModule extends AbstractApiModule {
    * @param {Function} next
    * @return {Promise}
    */
+  /**
+   * Lists the courses and assets owned by the route user (for a transfer preview).
+   * @param {external:ExpressRequest} req
+   * @param {external:ExpressResponse} res
+   * @param {Function} next
+   * @return {Promise}
+   */
+  async ownedContentHandler (req, res, next) {
+    try {
+      const authored = await this.app.waitForModule('authored')
+      res.json(await authored.getOwnedSummary(req.apiData.query._id))
+    } catch (e) {
+      next(e)
+    }
+  }
+
   async transferContentHandler (req, res, next) {
     try {
       const fromId = req.apiData.query._id

--- a/lib/UsersModule.js
+++ b/lib/UsersModule.js
@@ -130,6 +130,32 @@ class UsersModule extends AbstractApiModule {
     query.email = this.getConfig('forceLowerCaseEmail') ? query.email?.toLowerCase() : undefined
     return super.find(query, options, mongoOptions)
   }
+
+  /**
+   * Transfers all content owned by the route user to the user passed as `_toUser` in the request body.
+   * @param {external:ExpressRequest} req
+   * @param {external:ExpressResponse} res
+   * @param {Function} next
+   * @return {Promise}
+   */
+  async transferContentHandler (req, res, next) {
+    try {
+      const fromId = req.apiData.query._id
+      const toId = req.apiData.data?._toUser
+      if (!toId || toId === fromId) {
+        throw this.app.errors.INVALID_TRANSFER_TARGET.setData({ _toUser: toId })
+      }
+      const [target] = await this.find({ _id: toId })
+      if (!target) {
+        throw this.app.errors.INVALID_TRANSFER_TARGET.setData({ _toUser: toId })
+      }
+      const authored = await this.app.waitForModule('authored')
+      const moved = await authored.transferOwnership(fromId, toId)
+      res.json({ moved })
+    } catch (e) {
+      next(e)
+    }
+  }
 }
 
 export default UsersModule

--- a/routes.json
+++ b/routes.json
@@ -30,6 +30,19 @@
       "permissions": { "put": ["write:${scope}"], "get": ["read:${scope}"], "patch": ["write:${scope}"], "delete": ["write:${scope}"] }
     },
     {
+      "route": "/:_id/transfercontent",
+      "validate": false,
+      "modifying": false,
+      "handlers": { "post": "transferContentHandler" },
+      "permissions": { "post": ["write:${scope}"] },
+      "meta": {
+        "post": {
+          "summary": "Transfer content ownership to another user",
+          "description": "Reassigns all content and assets owned by this user (createdBy) to the user passed as _toUser in the request body. Use before deleting a user who owns content."
+        }
+      }
+    },
+    {
       "route": "/query",
       "validate": false,
       "modifying": false,

--- a/routes.json
+++ b/routes.json
@@ -30,6 +30,19 @@
       "permissions": { "put": ["write:${scope}"], "get": ["read:${scope}"], "patch": ["write:${scope}"], "delete": ["write:${scope}"] }
     },
     {
+      "route": "/:_id/ownedcontent",
+      "validate": false,
+      "modifying": false,
+      "handlers": { "get": "ownedContentHandler" },
+      "permissions": { "get": ["read:${scope}"] },
+      "meta": {
+        "get": {
+          "summary": "List the courses and assets owned by this user",
+          "description": "Returns the courses and assets whose createdBy is this user, for previewing a content-ownership transfer."
+        }
+      }
+    },
+    {
       "route": "/:_id/transfercontent",
       "validate": false,
       "modifying": false,


### PR DESCRIPTION
### Fixes #49

### New
- Add `POST /users/:_id/transfercontent` (write scope). Body: `{ "_toUser": "<userId>" }`.
- The handler validates `_toUser` (must be an existing user, different from the route user) and delegates to the authored module's `transferOwnership` to reassign all content the route user owns.
- New error `INVALID_TRANSFER_TARGET` for a missing/invalid `_toUser`.

This is the escape hatch that lets an admin move a content owner's work to another user before deleting the account.

### Testing
- Route registration confirmed on a running server (`/:_id/transfercontent` present with a POST handler).
- Transfer verified end-to-end against a live database via the authored module (owned counts move from source to target; source then owns nothing).
- `npx standard` clean.
